### PR TITLE
test(internal/auth): add some unit tests around basic and bearer auth

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+*       @flipt-io/maintainers

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 jobs:
-  dagger:
+  unit:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -14,4 +14,16 @@ jobs:
         with:
           version: "0.10.3"
           verb: call
-          args: test --source .
+          args: testUnit --source .
+
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Call Dagger Function
+        uses: dagger/dagger-for-github@v5
+        with:
+          version: "0.10.3"
+          verb: call
+          args: testIntegration --source .

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -49,7 +49,6 @@ func HandleBasic(username, password string) protocol.AuthenticationHandler {
 
 		return nil
 	})
-
 }
 
 // HandleBearer performs a bearer token comparison for register listener request metadata

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -1,0 +1,184 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.flipt.io/reverst/pkg/protocol"
+)
+
+var (
+	basic  = HandleBasic("morty", "gazorpazorp")
+	bearer = HandleBearer("plumbus")
+)
+
+func Test_Handlers(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		handler     protocol.AuthenticationHandler
+		request     protocol.RegisterListenerRequest
+		expectedErr error
+	}{
+		{
+			name:    "basic: matches",
+			handler: basic,
+			request: protocol.RegisterListenerRequest{
+				TunnelGroup: "sanchez",
+				Metadata: map[string]string{
+					"Authorization": "Basic bW9ydHk6Z2F6b3JwYXpvcnA=",
+				},
+			},
+		},
+		{
+			name:    "basic: missing metadata key",
+			handler: basic,
+			request: protocol.RegisterListenerRequest{
+				TunnelGroup: "sanchez",
+				Metadata: map[string]string{
+					"WrongKey": "Basic bW9ydHk6Z2F6b3JwYXpvcnA=",
+				},
+			},
+			expectedErr: ErrUnauthorized,
+		},
+		{
+			name:    "basic: unexpected scheme",
+			handler: basic,
+			request: protocol.RegisterListenerRequest{
+				TunnelGroup: "sanchez",
+				Metadata: map[string]string{
+					"Authorization": "Unknown bW9ydHk6Z2F6b3JwYXpvcnA=",
+				},
+			},
+			expectedErr: ErrUnauthorized,
+		},
+		{
+			name:    "basic: unexpected encoding",
+			handler: basic,
+			request: protocol.RegisterListenerRequest{
+				TunnelGroup: "sanchez",
+				Metadata: map[string]string{
+					"Authorization": "Basic th*s i% n@t b@$£64",
+				},
+			},
+			expectedErr: ErrUnauthorized,
+		},
+		{
+			name:    "basic: unexpected form (missing colon)",
+			handler: basic,
+			request: protocol.RegisterListenerRequest{
+				TunnelGroup: "sanchez",
+				Metadata: map[string]string{
+					"Authorization": "Basic bW9ydHlnYXpvcnBhem9ycA==",
+				},
+			},
+			expectedErr: ErrUnauthorized,
+		},
+		{
+			name:    "basic: unknown username",
+			handler: basic,
+			request: protocol.RegisterListenerRequest{
+				TunnelGroup: "sanchez",
+				Metadata: map[string]string{
+					"Authorization": "Basic ZXZpbG1vcnR5Om11bHRpdmVyc2U=",
+				},
+			},
+			expectedErr: ErrUnauthorized,
+		},
+		{
+			name:    "basic: unknown password",
+			handler: basic,
+			request: protocol.RegisterListenerRequest{
+				TunnelGroup: "sanchez",
+				Metadata: map[string]string{
+					"Authorization": "Basic bW9ydHk6bXVsdGl2ZXJzZQ==",
+				},
+			},
+			expectedErr: ErrUnauthorized,
+		},
+		{
+			name:    "bearer: matches",
+			handler: bearer,
+			request: protocol.RegisterListenerRequest{
+				TunnelGroup: "sanchez",
+				Metadata: map[string]string{
+					"Authorization": "Bearer plumbus",
+				},
+			},
+		},
+		{
+			name:    "bearer: missing metadata key",
+			handler: bearer,
+			request: protocol.RegisterListenerRequest{
+				TunnelGroup: "sanchez",
+				Metadata: map[string]string{
+					"WrongKey": "Basic bW9ydHk6Z2F6b3JwYXpvcnA=",
+				},
+			},
+			expectedErr: ErrUnauthorized,
+		},
+		{
+			name:    "bearer: unexpected scheme",
+			handler: bearer,
+			request: protocol.RegisterListenerRequest{
+				TunnelGroup: "sanchez",
+				Metadata: map[string]string{
+					"Authorization": "Unknown plumbus",
+				},
+			},
+			expectedErr: ErrUnauthorized,
+		},
+		{
+			name:    "bearer: unknown token",
+			handler: bearer,
+			request: protocol.RegisterListenerRequest{
+				TunnelGroup: "sanchez",
+				Metadata: map[string]string{
+					"Authorization": "Bearer wubalubadubdub",
+				},
+			},
+			expectedErr: ErrUnauthorized,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.handler.Authenticate(&test.request)
+			if test.expectedErr == nil {
+				require.NoError(t, err)
+				return
+			}
+
+			require.ErrorIs(t, err, test.expectedErr)
+		})
+	}
+}
+
+func FuzzBasic(f *testing.F) {
+	f.Add("someunexpectedpayload")
+	f.Add("Basic th*s i% n@t b@$£64")
+	f.Add("Basic c29tZWludmFsaWQ6Y29tYmluYXRpb24=")
+	f.Fuzz(func(t *testing.T, a string) {
+		require.ErrorIs(t, basic.Authenticate(
+			&protocol.RegisterListenerRequest{
+				TunnelGroup: "sanchez",
+				Metadata: map[string]string{
+					"Authorization": a,
+				},
+			},
+		), ErrUnauthorized)
+	})
+}
+
+func FuzzBearer(f *testing.F) {
+	f.Add("someunexpectedpayload")
+	f.Add("Bearer th*s i% n@t b@$£64")
+	f.Add("Bearer c29tZWludmFsaWQ6Y29tYmluYXRpb24=")
+	f.Fuzz(func(t *testing.T, a string) {
+		require.ErrorIs(t, bearer.Authenticate(
+			&protocol.RegisterListenerRequest{
+				TunnelGroup: "sanchez",
+				Metadata: map[string]string{
+					"Authorization": a,
+				},
+			},
+		), ErrUnauthorized)
+	})
+}


### PR DESCRIPTION
Popped some unit tests in the `internal/auth` package around handling basic auth and bearer tokens.