### PR TITLE
feat(auth): add external authorization support to tunnel registering

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,30 +21,6 @@ A tunnel group is a load-balanced set of client-servers, which is exposed throug
   <img width="800" height="1199" src="./diagram.png" alt="Tunnel Lifecycle">
 </p>
 
-## Usage
-
-### `reverst` tunnel server
-
-```console
-➜  reverst -h
-COMMAND
-  reverst
-
-USAGE
-  reverst [FLAGS]
-
-FLAGS
-  -l, --log LEVEL                    debug, info, warn or error (default: INFO)
-  -a, --tunnel-address STRING        address for accepting tunnelling quic connections (default: 127.0.0.1:7171)
-  -s, --http-address STRING          address for serving HTTP requests (default: 127.0.0.1:8181)
-  -g, --tunnel-groups STRING         path to tunnel groups configuration file (default: groups.yml)
-  -n, --server-name STRING           server name used to identify tunnel via TLS (required)
-  -k, --private-key-path STRING      path to TLS private key PEM file (required)
-  -c, --certificate-path STRING      path to TLS certificate PEM file (required)
-      --max-idle-timeout DURATION    maximum time a connection can be idle (default: 1m0s)
-      --keep-alive-period DURATION   period between keep-alive events (default: 30s)
-```
-
 ## Client
 
 ### Install
@@ -58,10 +34,6 @@ go get go.flipt.io/reverst/client
 ```console
 go install ./client/...
 ```
-
-### Usage
-
-See [./client](./client) directory for more details.
 
 ## Server
 
@@ -130,3 +102,69 @@ Be sure to include the `Host` header, as this is used to route requests to the r
 ```curl
 curl -H 'Host: flipt.dev.local' 127.0.0.1:8181/fo
 ```
+
+### Usage and Configuration
+
+#### Command-Line Flags and Environment Variables
+
+The following flags can be used to configure a running instance of the `reverst` server.
+
+```console
+➜  reverst -h
+COMMAND
+  reverst
+
+USAGE
+  reverst [FLAGS]
+
+FLAGS
+  -l, --log LEVEL                    debug, info, warn or error (default: INFO)
+  -a, --tunnel-address STRING        address for accepting tunnelling quic connections (default: 127.0.0.1:7171)
+  -s, --http-address STRING          address for serving HTTP requests (default: 127.0.0.1:8181)
+  -g, --tunnel-groups STRING         path to tunnel groups configuration file (default: groups.yml)
+  -n, --server-name STRING           server name used to identify tunnel via TLS (required)
+  -k, --private-key-path STRING      path to TLS private key PEM file (required)
+  -c, --certificate-path STRING      path to TLS certificate PEM file (required)
+      --max-idle-timeout DURATION    maximum time a connection can be idle (default: 1m0s)
+      --keep-alive-period DURATION   period between keep-alive events (default: 30s)
+```
+
+The long form names of each flag can also be referenced as environment variable names.
+To do so, prefix them with `REVERST_`, replace each `-` with `_` and uppercase the letters.
+
+For example, `--tunnel-address` becomes `REVERST_TUNNEL_ADDRESS`.
+
+#### Tunnel Groups Configuration YAML
+
+The reverst server take a path to a YAML encoded file, which identifies the tunnel groups to be hosted.
+A tunnel group is a load-balancer on which tunneled servers can register themselves.
+The file contains a top-level key groups, under which each tunnel group is uniquely named.
+
+```yaml
+groups:
+  "group-name":
+    hosts:
+    - "some.host.address.dev" # Host for routing inbound HTTP requests to tunnel group
+    authentication:
+      type: "basic"
+      username: "user"
+      password: "pass"
+```
+
+Each group body contains import details for configuring the tunnel groups.
+
+**hosts**
+
+This is an array of strings which is used in routing HTTP requests to the tunnel group when one of the hostnames matches.
+
+**authentication**
+
+This identifies how to authenticate new tunnels attempting to register with the group.
+The following types are supported:
+
+- `basic` supports username and password authentication
+- `bearer` supports static token based matching
+- `external` supports offloading authentication and authorization to an external service
+- `insecure` disables authentication for the group (not advised for production)
+
+

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -104,6 +104,12 @@ func (g TunnelGroups) AuthenticationHandler() (protocol.AuthenticationHandler, e
 						return err
 					}
 				}
+			case "external":
+				var err error
+				handler, err = auth.HandleExternalAuthorizer(group.Authentication.AuthorizationEndpoint)
+				if err != nil {
+					return err
+				}
 			case "insecure":
 				handler = protocol.AuthenticationHandlerFunc(func(rlr *protocol.RegisterListenerRequest) error {
 					return nil
@@ -124,13 +130,14 @@ func (g TunnelGroups) AuthenticationHandler() (protocol.AuthenticationHandler, e
 type TunnelGroup struct {
 	Hosts          []string `json:"hosts,omitempty" yaml:"hosts,omitempty"`
 	Authentication struct {
-		Type            string `json:"type" yaml:"type"`
-		Username        string `json:"username,omitempty" yaml:"username,omitempty"`
-		Password        string `json:"password,omitempty" yaml:"password,omitempty"`
-		Token           string `json:"token,omitempty" yaml:"token,omitempty"`
-		TokenPath       string `json:"tokenPath,omitempty" yaml:"tokenPath,omitempty"`
-		HashedToken     string `json:"hashedToken,omitempty" yaml:"hashedToken,omitempty"`
-		HashedTokenPath string `json:"hashedTokenPath,omitempty" yaml:"hashedTokenPath,omitempty"`
+		Type                  string `json:"type" yaml:"type"`
+		Username              string `json:"username,omitempty" yaml:"username,omitempty"`
+		Password              string `json:"password,omitempty" yaml:"password,omitempty"`
+		Token                 string `json:"token,omitempty" yaml:"token,omitempty"`
+		TokenPath             string `json:"tokenPath,omitempty" yaml:"tokenPath,omitempty"`
+		HashedToken           string `json:"hashedToken,omitempty" yaml:"hashedToken,omitempty"`
+		HashedTokenPath       string `json:"hashedTokenPath,omitempty" yaml:"hashedTokenPath,omitempty"`
+		AuthorizationEndpoint string `json:"authorizationEndpoint,omitempty" yaml:"authorizationEndpoint,omitempty"`
 	} `json:"authentication,omitempty"`
 }
 
@@ -151,6 +158,10 @@ func (g TunnelGroup) Validate() error {
 			auth.HashedToken == "" &&
 			auth.HashedTokenPath == "" {
 			return errors.New("one of token, tokenPath, hashedToken or hashedTokenPath must be non-empty string (when auth-type == bearer)")
+		}
+	case "external":
+		if auth.AuthorizationEndpoint == "" {
+			return errors.New("authorizationEndpoint myst be non-empty string (when auth-type == external)")
 		}
 	case "insecure":
 		slog.Warn("Authentication type insecure has been chosen (requests will not be authenticated)")


### PR DESCRIPTION
Closes #4 

This adds support for authenticating tunnel registration via an external service.
Simple configure the tunnel group with an authorizing endpoint.
That endpoint should return with a status code `200 OK` to signify an authorized request.
Otherwise, all other responses will be treated as unauthorized.

All metadata on the registration requests is copied as headers on the call to the authorization service.

```yaml
groups:
  tunnel_group_one:
    hosts:
    - "some.tunnel.dev"
    authorization:
      type: "external"
      authorizationEndpoint: http://some.external.host/ext/auth
```