### PR TITLE
refactor!(auth): add support for configuring multiple auth strategies at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,9 +146,9 @@ groups:
     hosts:
     - "some.host.address.dev" # Host for routing inbound HTTP requests to tunnel group
     authentication:
-      type: "basic"
-      username: "user"
-      password: "pass"
+      basic:
+        username: "user"
+        password: "pass"
 ```
 
 Each group body contains import details for configuring the tunnel groups.
@@ -160,11 +160,37 @@ This is an array of strings which is used in routing HTTP requests to the tunnel
 **authentication**
 
 This identifies how to authenticate new tunnels attempting to register with the group.
+Multiple authentication strategies can be enabled at once.
 The following types are supported:
 
-- `basic` supports username and password authentication
-- `bearer` supports static token based matching
-- `external` supports offloading authentication and authorization to an external service
-- `insecure` disables authentication for the group (not advised for production)
+- `basic` supports username and password authentication (default scheme `Basic`)
+- `bearer` supports static token based matching (default scheme `Bearer`)
+- `external` supports offloading authentication and authorization to an external service (default scheme `Bearer`)
 
+> [!Note]: if enabling both `bearer` and `external` you will need to override one of their schemes to distinguish them.
 
+<details>
+
+<summary>Example configuration with multiple authentication strategies</summary>
+
+The following contains all three strategies (basic, bearer and external) enabled at once with different schemes:
+
+```yaml
+groups:
+  "group-name":
+    hosts:
+    - "some.host.address.dev" # Host for routing inbound HTTP requests to tunnel group
+    authentication:
+      basic:
+        username: "user"
+        password: "pass"
+      bearer:
+        token: "some-token"
+      external:
+        scheme: "JWT"
+        endpoint: "http://some-external-endpoint/auth/ext"
+```
+
+</details>
+
+If no strategies are supplied then authentication is disabled (strongly discouraged).

--- a/dagger/main.go
+++ b/dagger/main.go
@@ -106,9 +106,9 @@ func (m *Reverst) TestIntegration(
   "local.example":
     hosts: ["local.example"]
     authentication:
-      type: "basic"
-      username: "user"
-      password: "pass"
+      basic:
+        username: "user"
+        password: "pass"
 `,
 		}).
 		WithEnvVariable("REVERST_TUNNEL_GROUPS", "/etc/reverst/groups.yml").

--- a/examples/simple/group.yml
+++ b/examples/simple/group.yml
@@ -3,6 +3,6 @@ groups:
     hosts:
     - "flipt.dev.local"
     authentication:
-      type: "basic"
-      username: "user"
-      password: "pass"
+      basic:
+        username: "user"
+        password: "pass"

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -21,37 +21,76 @@ var ErrUnauthorized = errors.New("unauthorized")
 
 const unauthorizedMsg = "listener request unauthorized"
 
+type Authenticator map[string]Handler
+
+func (a Authenticator) Authenticate(r *protocol.RegisterListenerRequest) error {
+	log := slog.With("tunnel_group", r.TunnelGroup)
+
+	if len(a) == 0 {
+		log.Debug("No handlers configured skipping authentication")
+		return nil
+	}
+
+	auth, ok := r.Metadata["Authorization"]
+	if !ok {
+		log.Info(unauthorizedMsg, "reason", "missing authorization metadata")
+		return ErrUnauthorized
+	}
+
+	scheme, payload, ok := strings.Cut(strings.TrimSpace(auth), " ")
+	if !ok {
+		log.Info(unauthorizedMsg, "reason", "malformed authorization payload")
+		return ErrUnauthorized
+	}
+
+	log = log.With("scheme", scheme)
+
+	handler, ok := a[scheme]
+	if !ok {
+		log.Info(unauthorizedMsg, "reason", "unsupported scheme")
+		return ErrUnauthorized
+	}
+
+	if err := handler.Authenticate(scheme, payload); err != nil {
+		log.Info(unauthorizedMsg, "reason", err)
+		return ErrUnauthorized
+	}
+
+	return nil
+}
+
+type Handler interface {
+	Authenticate(scheme, payload string) error
+}
+
+type AuthenticationHandlerFunc func(scheme, payload string) error
+
+func (r AuthenticationHandlerFunc) Authenticate(scheme, payload string) error {
+	return r(scheme, payload)
+}
+
 // HandleBasic performs basic authentication for register listener request metadata
-func HandleBasic(username, password string) protocol.AuthenticationHandler {
+func HandleBasic(username, password string) Handler {
 	expectedUsername := safeComparator(username)
 	expectedPassword := safeComparator(password)
 
-	log := slog.With("auth_type", "basic")
-
-	return protocol.AuthenticationHandlerFunc(func(rlr *protocol.RegisterListenerRequest) error {
-		log := log.With("tunnel_group", rlr.TunnelGroup)
-
-		cred, err := parseAuthorization(rlr, "Basic ")
-		if err != nil {
-			log.Info(unauthorizedMsg, "error", err)
-			return ErrUnauthorized
+	return AuthenticationHandlerFunc(func(scheme, cred string) error {
+		if !strings.EqualFold(scheme, "Basic") {
+			return fmt.Errorf("basic: unexpected scheme %q", scheme)
 		}
 
 		dec, err := base64.StdEncoding.DecodeString(cred)
 		if err != nil {
-			log.Info(unauthorizedMsg, "error", err)
-			return ErrUnauthorized
+			return fmt.Errorf("basic: decoding credentials: %w", err)
 		}
 
 		username, password, ok := strings.Cut(string(dec), ":")
 		if !ok {
-			log.Info(unauthorizedMsg, "error", errors.New("missing username:password colon separator"))
-			return ErrUnauthorized
+			return errors.New("basic: unexpected payload format")
 		}
 
 		if !(expectedUsername(username) && expectedPassword(password)) {
-			log.Info(unauthorizedMsg, "error", errors.New("unexpected username or password"))
-			return ErrUnauthorized
+			return errors.New("basic: username or password unexpected")
 		}
 
 		return nil
@@ -59,23 +98,16 @@ func HandleBasic(username, password string) protocol.AuthenticationHandler {
 }
 
 // HandleBearer performs a bearer token comparison for register listener request metadata
-func HandleBearer(token string) protocol.AuthenticationHandler {
+func HandleBearer(token string) Handler {
 	expectedToken := safeComparator(token)
 
-	log := slog.With("auth_type", "bearer")
-
-	return protocol.AuthenticationHandlerFunc(func(rlr *protocol.RegisterListenerRequest) error {
-		log := log.With("tunnel_group", rlr.TunnelGroup)
-
-		token, err := parseAuthorization(rlr, "Bearer ")
-		if err != nil {
-			log.Info(unauthorizedMsg, "error", err)
-			return ErrUnauthorized
+	return AuthenticationHandlerFunc(func(scheme, token string) error {
+		if !strings.EqualFold(scheme, "Bearer") {
+			return fmt.Errorf("bearer: unexpected scheme %q", scheme)
 		}
 
 		if !expectedToken(token) {
-			log.Info(unauthorizedMsg, "error", errors.New("unexpected token"))
-			return ErrUnauthorized
+			return errors.New("bearer: token was not expected value")
 		}
 
 		return nil
@@ -84,53 +116,40 @@ func HandleBearer(token string) protocol.AuthenticationHandler {
 
 // HandleBearerHashed performs a bearer token comparison for register listener request metadata
 // It expects the token to have been pre-hashed using sha256 and encoded as a hexidecimal string
-func HandleBearerHashed(hashedToken string) (protocol.AuthenticationHandler, error) {
+func HandleBearerHashed(hashedToken string) (Handler, error) {
 	expected, err := hex.DecodeString(hashedToken)
 	if err != nil {
 		return nil, err
 	}
 
-	log := slog.With("auth_type", "bearer_hashed")
-
-	return protocol.AuthenticationHandlerFunc(func(rlr *protocol.RegisterListenerRequest) error {
-		log := log.With("tunnel_group", rlr.TunnelGroup)
-
-		token, err := parseAuthorization(rlr, "Bearer ")
-		if err != nil {
-			log.Info(unauthorizedMsg, "error", err)
-			return ErrUnauthorized
+	return AuthenticationHandlerFunc(func(scheme, token string) error {
+		if !strings.EqualFold(scheme, "Bearer") {
+			return fmt.Errorf("bearer: unexpected scheme %q", scheme)
 		}
 
 		sum := sha256.Sum256([]byte(token))
 		if subtle.ConstantTimeCompare(expected, sum[:]) != 1 {
-			log.Info(unauthorizedMsg, "error", errors.New("unexpected token"))
-			return ErrUnauthorized
+			return errors.New("bearer: token was not expected value")
 		}
 
 		return nil
 	}), nil
 }
 
-func HandleExternalAuthorizer(addr string) (protocol.AuthenticationHandler, error) {
+func HandleExternalAuthorizer(addr string) (Handler, error) {
 	if _, err := url.Parse(addr); err != nil {
 		return nil, fmt.Errorf("building external authorizer: %w", err)
 	}
 
 	client := &http.Client{}
 
-	log := slog.With("auth_type", "external")
-
-	return protocol.AuthenticationHandlerFunc(func(rlr *protocol.RegisterListenerRequest) error {
-		log := log.With("tunnel_group", rlr.TunnelGroup)
-
+	return AuthenticationHandlerFunc(func(scheme, payload string) error {
 		req, err := http.NewRequest("GET", addr, nil)
 		if err != nil {
 			return err
 		}
 
-		for k, v := range rlr.Metadata {
-			req.Header.Set(k, v)
-		}
+		req.Header.Set("Authorization", fmt.Sprintf("%s %s", scheme, payload))
 
 		resp, err := client.Do(req)
 		if err != nil {
@@ -144,23 +163,8 @@ func HandleExternalAuthorizer(addr string) (protocol.AuthenticationHandler, erro
 
 		body, _ := io.ReadAll(resp.Body)
 
-		log.Info(unauthorizedMsg, "response", string(body), "status", resp.Status)
-
-		return ErrUnauthorized
+		return fmt.Errorf("external: unexpected response (status %d) %q", resp.StatusCode, string(body))
 	}), nil
-}
-
-func parseAuthorization(r *protocol.RegisterListenerRequest, expectedScheme string) (string, error) {
-	auth, ok := r.Metadata["Authorization"]
-	if !ok {
-		return "", errors.New("authorization metadata not found")
-	}
-
-	if len(auth) < len(expectedScheme) || !strings.EqualFold(auth[:len(expectedScheme)], expectedScheme) {
-		return "", errors.New("unexpected authorization scheme")
-	}
-
-	return auth[len(expectedScheme):], nil
 }
 
 func safeComparator(expected string) func(string) bool {


### PR DESCRIPTION
Upon reflection it became useful for us to enable multiple authentication strategies at once.
So this PR makes a breaking change to the tunnel group configuration for authentication.
This makes it so that you can enable multiple strategies at once.
The scheme for each strategy is used to pick a matching authorizer.
The scheme can be overridden at configuration time, but each strategy has a default (see README).