### PR TITLE
refactor(server): introduce not found and client server backoff

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.25.0
 	golang.org/x/sync v0.7.0
 	gopkg.in/yaml.v2 v2.4.0
+	k8s.io/api v0.30.0
 	k8s.io/apimachinery v0.30.0
 	k8s.io/client-go v0.30.0
 )
@@ -39,6 +40,7 @@ require (
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20240430035430-e4905b036c4e // indirect
 	github.com/google/uuid v1.3.0 // indirect
+	github.com/imdario/mergo v0.3.6 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
@@ -51,6 +53,7 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/quic-go/qpack v0.4.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.25.0 // indirect
 	go.opentelemetry.io/otel/trace v1.25.0 // indirect
@@ -69,7 +72,6 @@ require (
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.30.0 // indirect
 	k8s.io/klog/v2 v2.120.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b // indirect

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/google/pprof v0.0.0-20240430035430-e4905b036c4e h1:RsXNnXE59RTt8o3DcA
 github.com/google/pprof v0.0.0-20240430035430-e4905b036c4e/go.mod h1:kf6iHlnVGwgKolg33glAes7Yg/8iWP8ukqeldJSO7jw=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/imdario/mergo v0.3.6 h1:xTNEAn+kxVO7dTZGu0CegyqKZmoWFI0rF8UxjlB2d28=
+github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -386,6 +386,13 @@ func (s *Server) register(conn quic.EarlyConnection) (err error) {
 		)
 	}()
 
+	tripper, ok := s.trippers[req.TunnelGroup]
+	if !ok {
+		err := fmt.Errorf("tunnel group not found: %q", req.TunnelGroup)
+		_ = w.write(err, protocol.CodeNotFound)
+		return err
+	}
+
 	if err := s.handler.Authenticate(&req); err != nil {
 		code := protocol.CodeServerError
 		if errors.Is(err, auth.ErrUnauthorized) {
@@ -394,13 +401,6 @@ func (s *Server) register(conn quic.EarlyConnection) (err error) {
 		}
 
 		_ = w.write(err, code)
-		return err
-	}
-
-	tripper, ok := s.trippers[req.TunnelGroup]
-	if !ok {
-		err := fmt.Errorf("tunnel group unknown: %q", req.TunnelGroup)
-		_ = w.write(err, protocol.CodeBadRequest)
 		return err
 	}
 

--- a/pkg/protocol/protocol.go
+++ b/pkg/protocol/protocol.go
@@ -18,6 +18,7 @@ type ResponseCode uint8
 const (
 	CodeOK ResponseCode = iota
 	CodeBadRequest
+	CodeNotFound
 	CodeUnauthorized
 	CodeServerError
 )

--- a/pkg/protocol/responsecode_string.go
+++ b/pkg/protocol/responsecode_string.go
@@ -10,13 +10,14 @@ func _() {
 	var x [1]struct{}
 	_ = x[CodeOK-0]
 	_ = x[CodeBadRequest-1]
-	_ = x[CodeUnauthorized-2]
-	_ = x[CodeServerError-3]
+	_ = x[CodeNotFound-2]
+	_ = x[CodeUnauthorized-3]
+	_ = x[CodeServerError-4]
 }
 
-const _ResponseCode_name = "CodeOKCodeBadRequestCodeUnauthorizedCodeServerError"
+const _ResponseCode_name = "CodeOKCodeBadRequestCodeNotFoundCodeUnauthorizedCodeServerError"
 
-var _ResponseCode_index = [...]uint8{0, 6, 20, 36, 51}
+var _ResponseCode_index = [...]uint8{0, 6, 20, 32, 48, 63}
 
 func (i ResponseCode) String() string {
 	if i >= ResponseCode(len(_ResponseCode_index)-1) {


### PR DESCRIPTION
This does a couple things:

1. Introduces a NotFound response code for when tunnels are not found
2. Adds expoential backoff to dialing and serving with the client