### PR TITLE
fix(client): dont shadow context cancel on DialAndServe error

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -141,7 +141,7 @@ func (s *Server) DialAndServe(ctx context.Context, addr string) (err error) {
 
 	// this signifies that the exponential backoff was exhausted or exceeded a deadline
 	// in this situation we simply return the last observed error in the dial and serve attempts
-	if wait.Interrupted(err) {
+	if !errors.Is(err, context.Canceled) && wait.Interrupted(err) {
 		err = lastErr
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -419,6 +419,8 @@ type responseWriter struct {
 }
 
 func (w *responseWriter) write(err error, code protocol.ResponseCode) error {
+	w.code = code
+
 	resp := &protocol.RegisterListenerResponse{
 		Version: protocol.Version,
 		Code:    code,


### PR DESCRIPTION
This ensures that context.Canceled is forwarded when `DialAndServe` is canceled.
Otherwise, this error is replaced with the last observed error during the retry loop.