### PR TITLE
fix(roundrobbin): ensure current cannot be out of bounds and evict only called once

### DIFF
--- a/dagger/main.go
+++ b/dagger/main.go
@@ -64,7 +64,7 @@ func (m *Reverst) TestUnit(
 		WithEnvVariable("CGO_ENABLED", "1").
 		WithMountedDirectory("/src", source).
 		WithWorkdir("/src").
-		WithExec([]string{"go", "test", "-race", "./..."}).
+		WithExec([]string{"go", "test", "-race", "-count=5", "./..."}).
 		Stdout(ctx)
 	if err != nil {
 		return out, err

--- a/internal/roundrobbin/set.go
+++ b/internal/roundrobbin/set.go
@@ -81,14 +81,21 @@ func (s *Set[T]) Next(ctx context.Context) (t T, ok bool, err error) {
 		}
 
 		var (
-			cur  = s.last.Load()
-			next = cur + 1
+			observed = s.last.Load()
+			cur      = observed
+			count    = uint64(len(s.entries))
 		)
-		if next >= uint64(len(s.entries)) {
+
+		if cur >= count {
+			cur = 0
+		}
+
+		next := cur + 1
+		if next >= count {
 			next = 0
 		}
 
-		if s.last.CompareAndSwap(cur, next) {
+		if s.last.CompareAndSwap(observed, next) {
 			return s.entries[cur], true, nil
 		}
 	}

--- a/internal/roundrobbin/set.go
+++ b/internal/roundrobbin/set.go
@@ -48,11 +48,13 @@ func (s *Set[T]) Register(ctx context.Context, t T) {
 }
 
 func (s *Set[T]) Remove(t T) {
+	var evicted bool
+
 	s.mu.Lock()
 	defer func() {
 		s.mu.Unlock()
 
-		if s.evicted != nil {
+		if s.evicted != nil && evicted {
 			s.evicted(t)
 		}
 	}()
@@ -60,6 +62,7 @@ func (s *Set[T]) Remove(t T) {
 	slog.Debug("roundrobbin set: removing entry")
 
 	s.entries = slices.DeleteFunc(s.entries, func(rt T) bool {
+		evicted = evicted || rt == t
 		return rt == t
 	})
 }


### PR DESCRIPTION
This PR defines some test cases that triggers two defects in the roundrobbin code.
It also includes the fix for both cases:

1. The evict handler can be called on remove even when the instance was not found
```
274: [68.1s] --- FAIL: Test_Set_RemoveConcurrent (0.00s)
274: [68.1s]     set_test.go:110: 
274: [68.1s]         	Error Trace:	/src/internal/roundrobbin/set_test.go:110
274: [68.1s]         	Error:      	Not equal: 
274: [68.1s]         	            	expected: 0x1
274: [68.1s]         	            	actual  : 0x14
274: [68.1s]         	Test:       	Test_Set_RemoveConcurrent
```

2. There is an easy to trigger out of bounds on a read after a removal

```
panic: runtime error: index out of range [1] with length 1

goroutine 13 [running]:
go.flipt.io/reverst/internal/roundrobbin.(*Set[...]).Next(0xc00007e340, {0x776a00?, 0x95a3c0})
	/src/internal/roundrobbin/set.go:92 +0x3d5
go.flipt.io/reverst/internal/roundrobbin.Test_Set_RemoveConcurrent.func2()
	/src/internal/roundrobbin/set_test.go:94 +0xea
created by go.flipt.io/reverst/internal/roundrobbin.Test_Set_RemoveConcurrent in goroutine 10
	/src/internal/roundrobbin/set_test.go:91 +0x350
FAIL	go.flipt.io/reverst/internal/roundrobbin	0.015s
```

The test introduces some concurrent reads and removals of the same instance from a set.
The test has been updated to be run with a non-zero count to increase chance of triggering the failure.
The tests were pushed before the fixes to demonstrate the problem in CI.