### PR TITLE
fix(server/client): fix propagation of client errors from server to client

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -134,6 +134,14 @@ func (s *Server) DialAndServe(ctx context.Context, addr string) (err error) {
 				return false, nil
 			}
 
+			// these errors are considered non-recoverable
+			// not-found is considered recoverable under the situation that the
+			// tunnel has recently been requested for provisioning and is coming online
+			if errors.Is(err, ErrUnauthorized) ||
+				errors.Is(err, ErrBadRequest) {
+				return false, err
+			}
+
 			// we log out the error under debug as this function will be repeated
 			// and hopefully will eventually succeed
 			// if not then the last observed error should be returned and logged

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -14,6 +14,6 @@ const (
 var (
 	tunnelGroupKey = attribute.Key("tunnel_group")
 	hostKey        = attribute.Key("host")
-	statusKey      = attribute.Key("error")
+	statusKey      = attribute.Key("status")
 	errorKey       = attribute.Key("error")
 )

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -14,5 +14,6 @@ const (
 var (
 	tunnelGroupKey = attribute.Key("tunnel_group")
 	hostKey        = attribute.Key("host")
-	statusKey      = attribute.Key("status")
+	statusKey      = attribute.Key("error")
+	errorKey       = attribute.Key("error")
 )


### PR DESCRIPTION
This changes up the protocol to effectively drop (while leaving it always reporting OK) the response code from the registration response. Instead, we lean into the application error on connection close instead.
In all situations, we're closing the entire connection when these errors occur (tunnel not found, bad request, unauthorized).

This fixes an issue where while trying to write a response, close the stream and then close the connection, the downstream client would always just get the connection error above all else. The response on the stream wasn't getting a chance to be read and parsed first.

There is a new test added to the ITs which ensures that a `client.ErrUnauthorized` is returned as expected from `DialAndServe` when the reverst server sends it on connection close.
Addtionally, the retry with backoff has been updated to skip retries on both unuathorized and bad request. Not found is still considered retriable to support the situation where the tunnel was just previously created by `cloud serve` and needs a moment to be provisioned.