### PR TITLE
feat(gh): push latest tag on commits to main for images which are already tagged using the associated SHA

### DIFF
--- a/.github/workflows/publish-latest.yml
+++ b/.github/workflows/publish-latest.yml
@@ -1,0 +1,33 @@
+name: 'Publish Latest'
+
+on:
+  push:
+    branches:
+    - "main"
+
+# limit concurrency of workflow to one run at a time
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  publish-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tag current SHA being pushed to main as latest
+        run: |
+          docker buildx imagetools create \
+            --tag ghcr.io/${{ github.repository }}:latest \
+            ghcr.io/${{ github.repository }}:${{ github.sha }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,10 +1,8 @@
 name: 'Publish'
 
 on:
+  workflow_dispatch:
   merge_group:
-  push:
-    branches:
-    - gh-readonly-queue/**
 
 jobs:
   publish-image:


### PR DESCRIPTION
The current workflow for publishing reverst container is to build and push it with its own git SHA as its tag.
This is done during the merge queue phase, which ensures that once the commit lands in main that the relative image is pushed to GH container registry already (one caveat is there might be a slight race due to branch requirements).

The workflow added in this PR introduces a run which, once a commit lands in `main` it will trigger and re-tag the SHA as latest.
This results in images both tagged by their Git SHA and the `latest` being tagged for convenience.