### PR TITLE
fix(config): correctly set token supplied via explicit token field

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -247,7 +247,7 @@ func (a *AuthenticationBearer) Validate(ctx context.Context) (err error) {
 		return err
 	}
 
-	if len(token) == 0 {
+	if len(token) > 0 {
 		return setStaticTokenSource(token)
 	}
 


### PR DESCRIPTION
I borked the logic here.
It should be setting the token when its not empty.